### PR TITLE
Add git_proto parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,9 +1,10 @@
 # Install MRepo
 class rhel_mrepo_profiles(
-  $mirror_root   = '/srv/mrepo',
-  $source        = 'git',
-  $port          = '80',
+  $mirror_root       = '/srv/mrepo',
+  $source            = 'git',
+  $port              = '80',
   $install_local_rpm = false,
+  $git_proto         = 'git',
 ) {
 
   $staging_target = "${mirror_root}/iso"
@@ -30,6 +31,7 @@ class rhel_mrepo_profiles(
     user       => 'root',
     group      => 'root',
     port       => $port,
+    git_proto  => $git_proto,
   }
 
   if $install_local_rpm {


### PR DESCRIPTION
Where I am, firewall will allow cloning over https/ssh, but not over the
port the 'git' protocol uses.
